### PR TITLE
Revert "Bump highlight.js from 9.18.1 to 10.4.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "highlight.js": "^10.4.1",
+    "highlight.js": "^9.13.1",
     "husky": "^1.1.2",
     "mini-css-extract-plugin": "^0.4.3",
     "mocha": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,9 +3488,9 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
 
-highlight.js@^10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
+highlight.js@^9.13.1:
+  version "9.18.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Reverts codex-team/codex.docs#111