### PR TITLE
use codex bot token for creating new release

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,4 +17,4 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CODEX_GITHUB_BOT_TOKEN }}


### PR DESCRIPTION
Use @codex-github-bot token to trigger build workflow after publishing new release. Now we can't do it, because releases created via @github-actions bot.

More in docs: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow