### PR TITLE
fix critical issue with backward compatibility

### DIFF
--- a/src/backend/utils/crypto.ts
+++ b/src/backend/utils/crypto.ts
@@ -1,25 +1,16 @@
 import crypto from 'crypto';
 
 /**
- *
- * @param {string} hexStr - input hex string
- * @returns {string} - output binary string
- */
-function hexToBinary(hexStr: string): string {
-  return (parseInt(hexStr, 16).toString(2))
-    .padStart(8, '0');
-}
-
-/**
  * Create binary md5
  *
  * @param stringToHash - string to hash
  * @returns {string} - binary hash of argument
  */
 export function binaryMD5(stringToHash: string): string {
-  return hexToBinary(crypto.createHash('md5')
+  return crypto.createHash('md5')
     .update(stringToHash)
-    .digest('hex'));
+    .digest()
+    .toString('binary');
 }
 
 /**


### PR DESCRIPTION
I found critical issue with md5 hash generating, which appeared after [this change](https://github.com/codex-team/codex.docs/commit/34514761f5ca8109d3420568d89b905c87776523#diff-ecfcf7ddf289610107bccc09accc075d43edd913268e083272ccd4dc2bbd52ba)

This PR fixes this critical issue