### PR TITLE
change docker tag for stage branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,12 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value={{branch}}-{{sha}}-{{date 'X'}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
After this request, we can also use docker tag for stage in the following form `stage-b4d0b8c-1650817574` which is better for k8s deployment