### PR TITLE
feat: hide-sidebar-content-on-mobile

### DIFF
--- a/src/frontend/js/modules/sidebar.js
+++ b/src/frontend/js/modules/sidebar.js
@@ -36,7 +36,7 @@ export default class Sidebar {
       sidebarCollapsed: 'docs-sidebar--collapsed',
       sidebarAnimated: 'docs-sidebar--animated',
       sidebarContent: 'docs-sidebar__content',
-      sidebarContentHidden: 'docs-sidebar__content--hidden',
+      sidebarContentVisible: 'docs-sidebar__content--visible',
       sidebarContentInvisible: 'docs-sidebar__content--invisible',
     };
   }
@@ -182,7 +182,7 @@ export default class Sidebar {
    * @returns {void}
    */
   toggleSidebar() {
-    this.nodes.sidebarContent.classList.toggle(Sidebar.CSS.sidebarContentHidden);
+    this.nodes.sidebarContent.classList.toggle(Sidebar.CSS.sidebarContentVisible);
   }
 
   /**

--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -50,12 +50,13 @@
       padding-bottom: 0;
     }
 
-    @media (--mobile){
+    @media (--mobile) {
       margin: 0 -8px;
+      display: none;
     }
 
-    &--hidden {
-      display: none;
+    &--visible {
+      display: block;
     }
 
     &--invisible {


### PR DESCRIPTION
Resolves #234

Maybe we can remove unused `docs-sidebar__content--invisible` class name in `sidebar.twig`?