### PR TITLE
fix: indents of the writing header

### DIFF
--- a/src/frontend/styles/components/writing.pcss
+++ b/src/frontend/styles/components/writing.pcss
@@ -1,6 +1,6 @@
 .writing-header {
-  padding: 15px 0;
-  margin-top: calc(-1 * var(--layout-padding-vertical));
+  padding: 0 0 15px 0;
+  margin-top: 0;
   background: #fff;
   box-shadow: 0 3px 10px #fff;
   z-index: 2;

--- a/src/frontend/styles/layout.pcss
+++ b/src/frontend/styles/layout.pcss
@@ -1,6 +1,6 @@
 :root {
   /**
-   * Allows to dynamically set main column minimun margin left. 
+   * Allows to dynamically set main column minimun margin left.
    * Is used for adding extra space for editor controls in page edit mode (otherwise controls overlap sidebar)
    */
   --main-col-min-margin-left: 0px;
@@ -41,7 +41,7 @@
     box-sizing: border-box;
     display: flex;
     justify-content: space-between;
-    padding: 20px var(--layout-padding-horizontal);
+    padding: var(--layout-padding-vertical) var(--layout-padding-horizontal);
 
     @media (--desktop) {
       max-width: min(


### PR DESCRIPTION
Resolves #251 

Margins and paddings of the writing header were changed which resulted in a better page appearance on the different screen resolutions. 

Tablet screen
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/46301523/189527218-faa388d6-9d13-45ed-b91b-76574b8f18ef.png">

Desktop screen
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/46301523/189527303-b11b7c78-601e-4266-9c80-1be414dffa18.png">

