### PR TITLE
refactor: stretched function

### DIFF
--- a/src/backend/views/pages/blocks/image.twig
+++ b/src/backend/views/pages/blocks/image.twig
@@ -4,10 +4,6 @@
   {% set classes = classes|merge(['block-image__content--bordered']) %}
 {% endif %}
 
-{% if stretched %}
-  {% set classes = classes|merge(['block-image__content--stretched']) %}
-{% endif %}
-
 {% if withBackground %}
   {% set classes = classes|merge(['block-image__content--with-background']) %}
 {% endif %}

--- a/src/frontend/styles/components/page.pcss
+++ b/src/frontend/styles/components/page.pcss
@@ -278,16 +278,6 @@
      max-width: 100%;
    }
 
-   &--stretched {
-     max-width: none !important;
-     width: calc(100% + 120px) !important;
-     margin-left: -60px;
-
-     img, video {
-       width: 100%;
-     }
-   }
-
    &--bordered {
      img, video {
        border: 3px solid var(--color-line-gray);

--- a/src/frontend/styles/components/writing.pcss
+++ b/src/frontend/styles/components/writing.pcss
@@ -1,6 +1,6 @@
 .writing-header {
-  padding: 15px 0;
-  margin-top: calc(-1 * var(--layout-padding-vertical));
+  padding: 0 0 15px 0;
+  margin-top: 0;
   background: #fff;
   box-shadow: 0 3px 10px #fff;
   z-index: 2;

--- a/src/frontend/styles/components/writing.pcss
+++ b/src/frontend/styles/components/writing.pcss
@@ -104,9 +104,10 @@
   @apply --text-content-title;
 }
 
-
 .ce-block {
   @apply --content-block;
 }
 
-
+.cdx-settings-button[data-tune="stretched"] {
+  display: none;
+}

--- a/src/frontend/styles/layout.pcss
+++ b/src/frontend/styles/layout.pcss
@@ -1,6 +1,6 @@
 :root {
   /**
-   * Allows to dynamically set main column minimun margin left. 
+   * Allows to dynamically set main column minimun margin left.
    * Is used for adding extra space for editor controls in page edit mode (otherwise controls overlap sidebar)
    */
   --main-col-min-margin-left: 0px;
@@ -41,7 +41,7 @@
     box-sizing: border-box;
     display: flex;
     justify-content: space-between;
-    padding: 20px var(--layout-padding-horizontal);
+    padding: var(--layout-padding-vertical) var(--layout-padding-horizontal);
 
     @media (--desktop) {
       max-width: min(


### PR DESCRIPTION
Resolves #223

The problem is due to a stretched function. It was decided to remove this feature. Because in these realities, there is no way to implement this function correctly. Different indents from left and right do not allow to stretch the picture correctly. For this, the easiest way was chosen: hide this button.

After changes it looks like this:
<img width="869" alt="image" src="https://user-images.githubusercontent.com/46301523/189528343-a021aa6d-0320-4b3a-b2eb-a532043c9225.png">
