### PR TITLE
fix: same link header-anchors

### DIFF
--- a/src/backend/views/pages/blocks/header.twig
+++ b/src/backend/views/pages/blocks/header.twig
@@ -1,5 +1,5 @@
-<h{{ level }} id="{{ text | urlify  }}" class="block-header block-header--{{ level }} block-header--anchor">
-  <a href="#{{ text | urlify  }}">
+<h{{ level }} id="{{ linkNumber }}-{{ text | urlify  }}" class="block-header block-header--{{ level }} block-header--anchor">
+  <a href="#{{ linkNumber }}-{{ text | urlify  }}">
     {{ text }}
   </a>
 </h{{ level }}>

--- a/src/backend/views/pages/page.twig
+++ b/src/backend/views/pages/page.twig
@@ -1,6 +1,7 @@
 {% extends 'layout.twig' %}
 
 {% block body %}
+  {% set linkNumber = 0 %}
   <article class="page" data-module="page">
     <header class="page__header">
       <div class="page__header-nav">
@@ -37,6 +38,10 @@
         {# Skip first header, because it is already showed as a Title #}
         {% if not (loop.first and block.type == 'header') %}
           {% if block.type in ['paragraph', 'header', 'image', 'code', 'list', 'delimiter', 'table', 'warning', 'checklist', 'linkTool', 'raw', 'embed'] %}
+            {# Create the counter to make header-achors different. #}
+            {% if (block.type == 'header') %}
+              {% set linkNumber = linkNumber + 1 %}
+            {% endif %}
             <div class="page__content-block">
               {% include './blocks/' ~ block.type ~ '.twig' with block.data %}
             </div>


### PR DESCRIPTION
Resolves #203 

If headers had the same names, they couldn't have different links (anchors). And the second header with the same name or the third or ... etc open anchors for the first header with that name. So counter was created to the headers. Thanks to it, the anchors have an ordinal number of the link, which allows the links to be individual.

First anchors "Итого"
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46301523/189633081-e8c39865-5418-4c23-b945-1251d4cd369d.png">

Second anchors "Итого"
![image](https://user-images.githubusercontent.com/46301523/189632794-07241b65-36ab-44dd-98dd-b8c9c662f98f.png)

Third anchors "Итого"
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46301523/189633324-8df77a24-d886-4ab7-9ed0-9038d3873fc0.png">

At the same time, if you add a new heading or delete an old heading, then the link identification numbers of the heading will be updated. It will not work such that the numbers of the links will increase all the time.