### PR TITLE
chore(hawk): fix hawk using the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@codexteam/shortcuts": "^1.2.0",
     "@hawk.so/javascript": "^3.0.1",
-    "@hawk.so/nodejs": "^3.1.2",
+    "@hawk.so/nodejs": "^3.1.4",
     "config": "^3.3.6",
     "cookie-parser": "^1.4.5",
     "csurf": "^1.11.0",

--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -8,7 +8,7 @@ import routes from './routes/index.js';
 import HttpException from './exceptions/httpException.js';
 import * as dotenv from 'dotenv';
 import config from 'config';
-import { default as HawkCatcher } from '@hawk.so/nodejs';
+import HawkCatcher from '@hawk.so/nodejs';
 import os from 'os';
 import appConfig from 'config';
 import { downloadFavicon, FaviconData } from './utils/downloadFavicon.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,9 +922,9 @@
     "@hawk.so/types" "^0.1.13"
     error-stack-parser "^2.0.6"
 
-"@hawk.so/nodejs@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@hawk.so/nodejs/-/nodejs-3.1.2.tgz#b06229f0c8a0d8676412329511f9f2b01e492211"
+"@hawk.so/nodejs@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@hawk.so/nodejs/-/nodejs-3.1.4.tgz#62eb4ff1272559f0841a53d7931f6939b4c056fe"
   dependencies:
     "@hawk.so/types" "^0.1.15"
     axios "^0.21.1"


### PR DESCRIPTION
After that https://github.com/codex-team/hawk.nodejs/pull/39 update, we can use Hawk Node.js in ESM project. So I've updated this dependency.