### PR TITLE
chore(styles): list and image blocks style improved

### DIFF
--- a/src/frontend/styles/components/page.pcss
+++ b/src/frontend/styles/components/page.pcss
@@ -258,7 +258,11 @@
 .block-list {
   margin: 0;
   list-style: outside;
-  padding-left: 26px;
+  padding-left: 40px;
+
+  &--ordered {
+    list-style-type: decimal
+  }
 
   li:not(:last-of-type) {
     margin-bottom: 8px;

--- a/src/frontend/styles/components/page.pcss
+++ b/src/frontend/styles/components/page.pcss
@@ -270,8 +270,7 @@
  * ==================
  */
 .block-image {
- margin: 40px auto;
- text-align: center;
+ margin: 0 auto;
 
  &__content {
    img, video {
@@ -298,8 +297,9 @@
  }
 
  &__caption {
-   margin: 1em auto;
-   color: var(--color-text-second);
+    margin-top: 10px;
+    color: var(--color-text-second);
+    font-size: 0.9em;
  }
 }
 

--- a/src/frontend/styles/components/writing.pcss
+++ b/src/frontend/styles/components/writing.pcss
@@ -91,6 +91,10 @@
     padding: 6px 8px;
   }
 
+  .cdx-list {
+    padding-left: 40px;
+  }
+
   @media (--desktop) {
     .ce-block__content,
     .ce-toolbar__content {


### PR DESCRIPTION
1. Redundant margins around the image block removed
2. Image captions style updated
3. Fix list padding in Editor Resolves #259 
4. Fix list type ignore in Page 

![image](https://user-images.githubusercontent.com/3684889/189926055-c73c431d-a1d9-4f70-8474-d29609d2388e.png)


