### PR TITLE
Fix sidebar being impossible to hide on tablet screen

### DIFF
--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -59,6 +59,11 @@
       padding-bottom: 0;
     }
 
+    @media (--tablet) {
+      margin: 0 -8px;
+      display: none;
+    }
+
     @media (--mobile) {
       margin: 0 -8px;
       display: none;


### PR DESCRIPTION
Sidebar is not collapsing on toggler click at screens of width from 980px to 1049px