### PR TITLE
fix(styles): editor styles improved

### DIFF
--- a/src/frontend/styles/components/page.pcss
+++ b/src/frontend/styles/components/page.pcss
@@ -48,6 +48,10 @@
     &-button {
       margin-left: 20px;
       text-decoration: none;
+
+      @media (--mobile) {
+        margin-left: auto;
+      }
     }
   }
 

--- a/src/frontend/styles/components/page.pcss
+++ b/src/frontend/styles/components/page.pcss
@@ -58,6 +58,7 @@
   &__title {
     @apply --text-content-title;
     margin-bottom: 10px;
+    line-height: 1.35em;
   }
 
   .cdx-marker {
@@ -103,10 +104,12 @@
 .block-header {
   @apply --text-header;
 
+  margin-top: 10px;
   display: flex;
   align-items: center;
   transform: translateX(-36px);
   cursor: text;
+
   &--2 {
     @apply --text-header-2;
   }
@@ -336,17 +339,7 @@
  * ==================
  */
 .block-list {
-  margin: 0;
-  list-style: outside;
-  padding-left: 40px;
-
-  &--ordered {
-    list-style-type: decimal
-  }
-
-  li:not(:last-of-type) {
-    margin-bottom: 8px;
-  }
+  @apply --text-list;
 }
 
 /**

--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -60,13 +60,12 @@
     }
 
     @media (--tablet) {
-      margin: 0 -8px;
       display: none;
     }
 
     @media (--mobile) {
-      margin: 0 -8px;
       display: none;
+      padding: var(--layout-padding-vertical) 7px;
     }
 
     &--visible {

--- a/src/frontend/styles/components/writing.pcss
+++ b/src/frontend/styles/components/writing.pcss
@@ -58,13 +58,17 @@
     border-radius: 8px;
   }
 
-  .ce-paragraph a {
-    @apply --text-inline-link;
+  .ce-paragraph {
+    line-height: inherit;
+
+    a {
+     @apply --text-inline-link;
+    }
   }
 
   .ce-header {
     @apply --text-header;
-    padding: 0;
+    padding: 0 0 10px;
   }
 
   h2.ce-header {
@@ -73,10 +77,6 @@
 
   h3.ce-header {
     @apply --text-header-3;
-  }
-
-  .cdx-block {
-    padding: 0;
   }
 
   .inline-code {
@@ -92,7 +92,11 @@
   }
 
   .cdx-list {
-    padding-left: 40px;
+    @apply --text-list;
+
+    &__item {
+      line-height: inherit;
+    }
   }
 
   @media (--desktop) {
@@ -107,7 +111,7 @@
   @apply --text-content-title;
 }
 
-.ce-block {
+.cdx-block {
   @apply --content-block;
 }
 

--- a/src/frontend/styles/vars.pcss
+++ b/src/frontend/styles/vars.pcss
@@ -148,7 +148,7 @@
    * The common styles for the Page blocks as well as Editor blocks
    */
   --content-block {
-    margin: 20px 0;
+    padding: 10px 0;
   }
 
   /**
@@ -184,7 +184,7 @@
    * Common styles for text headings (H2, H3, H4)
    */
   --text-header {
-    margin: 28px 0 0;
+    margin: 20px 0 0;
     line-height: 1.35em;
   }
 
@@ -253,6 +253,27 @@
 
       &:hover {
         background-color: #c8edfe;
+      }
+    }
+  }
+
+  /**
+   * Styles for the List block
+   */
+  --text-list {
+    margin: 0;
+    list-style: outside;
+    padding-left: 40px;
+
+    &--ordered {
+      list-style-type: decimal
+    }
+
+    li {
+      padding: 0;
+
+      &:not(:last-of-type){
+        margin-bottom: 8px;
       }
     }
   }

--- a/src/frontend/styles/vars.pcss
+++ b/src/frontend/styles/vars.pcss
@@ -148,7 +148,7 @@
    * The common styles for the Page blocks as well as Editor blocks
    */
   --content-block {
-    padding: 10px 0;
+    margin: 20px 0;
   }
 
   /**
@@ -184,7 +184,7 @@
    * Common styles for text headings (H2, H3, H4)
    */
   --text-header {
-    margin: 18px 0 0;
+    margin: 28px 0 0;
     line-height: 1.35em;
   }
 


### PR DESCRIPTION
## 1. Editor toolbar offset fixed 

### Before 
<img width="391" alt="image" src="https://user-images.githubusercontent.com/3684889/190489270-691623f0-3b2f-4a5b-9cae-71421f88ac1a.png">

### After 

<img width="334" alt="image" src="https://user-images.githubusercontent.com/3684889/190489336-db8511fa-58f4-46e2-85a7-d58e07f9cbfe.png">

## 2. Mobile Menu horisontal scroll fixed

Resolves #267 

## 3. Typography style difference between Editor and Page decreased

Now the document at Editor and at the Page looks similar:

- Line height unified 
- Header paddigns/margins has been made more similar
- List styles unified

## 4. Mobile Edit button now aligned at the right

### Before 

<img width="415" alt="image" src="https://user-images.githubusercontent.com/3684889/190490336-7535b36f-136a-4bd6-abb7-1f883246ec15.png">

### After 

<img width="453" alt="image" src="https://user-images.githubusercontent.com/3684889/190490367-1e5bdf5b-c923-456c-a4a4-652b56dd3078.png">
