### PR TITLE
Fix sidebar and table of contents position

### DIFF
--- a/src/frontend/styles/layout.pcss
+++ b/src/frontend/styles/layout.pcss
@@ -8,7 +8,6 @@
 
 .docs {
   min-height: calc(100vh - var(--layout-height-header));
-  overflow-x: hidden;
 
   @media (--desktop) {
     display: flex;


### PR DESCRIPTION
CSS property `overflow` breaks sticky positioning of sidebar and table of contents 