### PR TITLE
Added enable parameter for rendering index page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex.docs",
   "license": "Apache-2.0",
-  "version": "v2.0.0-rc.4",
+  "version": "v2.2.0-rc.1",
   "type": "module",
   "bin": {
     "codex.docs": "dist/backend/app.js"

--- a/src/backend/build-static.ts
+++ b/src/backend/build-static.ts
@@ -111,7 +111,10 @@ export default async function buildStatic(): Promise<void> {
     await renderPage(page);
   }
 
-  await renderIndexPage(config.indexPageUri);
+  // Check if index page is enabled
+  if (config.indexPage.enabled) {
+    await renderIndexPage(config.indexPage.uri);
+  }
   console.log('Static files built');
 
   console.log('Copy public directory');

--- a/src/backend/utils/appConfig.ts
+++ b/src/backend/utils/appConfig.ts
@@ -90,7 +90,10 @@ const FrontendConfig = z.object({
  */
 const StaticBuildConfig = z.object({
   outputDir: z.string(), // Output directory for static build
-  indexPageUri: z.string(), // URI for index page to render
+  indexPage: z.object({
+    enabled: z.boolean(), // Is index page enabled
+    uri: z.string(), // Index page uri
+  }),
 });
 
 export type StaticBuildConfig = z.infer<typeof StaticBuildConfig>;


### PR DESCRIPTION
If parameter `enabled` for index page is `false`, static file `index.html` will not create