### PR TITLE
Fixed copy button path in header.twig, code.twig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex.docs",
   "license": "Apache-2.0",
-  "version": "v2.2.0-rc.3",
+  "version": "v2.2.0-rc.7",
   "type": "module",
   "bin": {
     "codex.docs": "dist/backend/app.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex.docs",
   "license": "Apache-2.0",
-  "version": "v2.2.0-rc.7",
+  "version": "v2.2.0-rc.11",
   "type": "module",
   "bin": {
     "codex.docs": "dist/backend/app.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex.docs",
   "license": "Apache-2.0",
-  "version": "v2.2.0-rc.1",
+  "version": "v2.2.0-rc.3",
   "type": "module",
   "bin": {
     "codex.docs": "dist/backend/app.js"

--- a/src/backend/build-static.ts
+++ b/src/backend/build-static.ts
@@ -45,8 +45,10 @@ export default async function buildStatic(): Promise<void> {
     });
   }
 
-  console.log('Removing old static files');
-  await fse.remove(distPath);
+  if (config.overwrite) {
+    console.log('Removing old static files');
+    await fse.remove(distPath);
+  }
 
   console.log('Building static files');
   const pagesOrder = await PagesOrder.getAll();

--- a/src/backend/build-static.ts
+++ b/src/backend/build-static.ts
@@ -118,11 +118,22 @@ export default async function buildStatic(): Promise<void> {
   console.log('Static files built');
 
   console.log('Copy public directory');
-  await fse.copy(path.resolve(dirname, '../../public'), distPath);
+  const publicDir = path.resolve(dirname, '../../public');
+
+  console.log(`Copy from ${publicDir} to ${distPath}`);
+
+  try {
+    await fse.copy(publicDir, distPath);
+    console.log('Public directory copied');
+  } catch (e) {
+    console.log('Error while copying public directory');
+    console.error(e);
+  }
 
   if (appConfig.uploads.driver === 'local') {
     console.log('Copy uploads directory');
     await fse.copy(path.resolve(cwd, appConfig.uploads.local.path), path.resolve(distPath, 'uploads'));
+    console.log('Uploads directory copied');
   }
 }
 

--- a/src/backend/utils/appConfig.ts
+++ b/src/backend/utils/appConfig.ts
@@ -90,6 +90,7 @@ const FrontendConfig = z.object({
  */
 const StaticBuildConfig = z.object({
   outputDir: z.string(), // Output directory for static build
+  overwrite: z.boolean().optional().default(true),
   indexPage: z.object({
     enabled: z.boolean(), // Is index page enabled
     uri: z.string(), // Index page uri

--- a/src/backend/views/pages/blocks/code.twig
+++ b/src/backend/views/pages/blocks/code.twig
@@ -3,7 +3,7 @@
     <div class="block-code__content">{{ code | escape }}</div>
   </div>
   {%
-    include 'components/copy-button.twig' with {
+    include '../../components/copy-button.twig' with {
       ariaLabel: 'Copy Code to Clipboard',
       class: 'block-code__copy-button',
       textToCopy: code | escape,

--- a/src/backend/views/pages/blocks/header.twig
+++ b/src/backend/views/pages/blocks/header.twig
@@ -1,6 +1,6 @@
 <h{{ level }} id="{{ text | urlify  }}" class="block-header block-header--{{ level }}">
   {%
-    include 'components/copy-button.twig' with {
+    include '../../components/copy-button.twig' with {
       ariaLabel: 'Copy Link to the ' ~ text,
       class: 'block-header__copy-button',
       textToCopy: '#' ~ text | urlify,


### PR DESCRIPTION
Changed `copy-button.twig` path in `header.twig` and `code.twig` in the reason of error while building static files