### PR TITLE
fix(ui): broken sidebar, table of content and header on  linux

### DIFF
--- a/src/frontend/styles/components/header.pcss
+++ b/src/frontend/styles/components/header.pcss
@@ -40,7 +40,10 @@ html {
 
     @media (--not-mobile) {
       padding: 4px 10px;
-      @apply --squircle;
+
+      &:hover {
+        @apply --squircle;
+      }
     }
 
     &:hover {

--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -189,7 +189,7 @@
     }
 
     &--active,
-    &--hover {
+    &:hover {
       @apply --squircle;
     }
   }

--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -182,12 +182,15 @@
     transition-property: background-color;
     transition-duration: 0.1s;
 
-    @apply --squircle;
-
     &--selected {
       border-radius: 8px;
       /* border using box-shadow which doesn't increase the height */
       box-shadow: 0 0 0 2px rgba(147, 166, 233, 0.5) inset;
+    }
+
+    &--active,
+    &--hover {
+      @apply --squircle;
     }
   }
 

--- a/src/frontend/styles/components/table-of-content.pcss
+++ b/src/frontend/styles/components/table-of-content.pcss
@@ -31,7 +31,10 @@
     gap: 2px;
 
     &-item {
-      @apply --squircle;
+      &:hover,
+      &--active {
+        @apply --squircle;
+      }
 
       &:hover {
         background-color: var(--color-link-hover);

--- a/src/frontend/styles/vars.pcss
+++ b/src/frontend/styles/vars.pcss
@@ -138,6 +138,7 @@
   --squircle {
     border-radius: 8px;
 
+
     @supports(-webkit-mask-box-image: url('')){
       border-radius: 0;
       -webkit-mask-box-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 10.3872C0 1.83334 1.83334 0 10.3872 0H13.6128C22.1667 0 24 1.83334 24 10.3872V13.6128C24 22.1667 22.1667 24 13.6128 24H10.3872C1.83334 24 0 22.1667 0 13.6128V10.3872Z' fill='black'/%3E%3C/svg%3E%0A") 48% 41% 37.9% 53.3%;;

--- a/src/frontend/styles/vars.pcss
+++ b/src/frontend/styles/vars.pcss
@@ -138,7 +138,6 @@
   --squircle {
     border-radius: 8px;
 
-
     @supports(-webkit-mask-box-image: url('')){
       border-radius: 0;
       -webkit-mask-box-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 10.3872C0 1.83334 1.83334 0 10.3872 0H13.6128C22.1667 0 24 1.83334 24 10.3872V13.6128C24 22.1667 22.1667 24 13.6128 24H10.3872C1.83334 24 0 22.1667 0 13.6128V10.3872Z' fill='black'/%3E%3C/svg%3E%0A") 48% 41% 37.9% 53.3%;;


### PR DESCRIPTION
## Problem 

We've found a strange behavior in some UI components on Linux. Seems like a bug on a GPU side.

<img width="1200" alt="image" src="https://github.com/codex-team/codex.docs/assets/3684889/f245d0af-5435-40f5-81ca-f252963977f6">

## Cause

During debug I noticed, that problem disappears when we hover an element. In other words, the problem reproduced only on elements without `background`.

The second reason is our `--squircle` mixin which used `-webkit-mask-box-image` internally. If we disable it, problem disappeared.

## Solution

I've disabled squircle on default states of elements. Now we're adding it only when it has a bg (on hover or active state)


Resolves #314 