### PR TITLE
Sidebar: bold top-level items only; tighter spacing after collapsed sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex.docs",
   "license": "Apache-2.0",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "type": "module",
   "bin": {
     "codex.docs": "dist/backend/app.js"

--- a/src/backend/views/components/sidebar-section.twig
+++ b/src/backend/views/components/sidebar-section.twig
@@ -1,9 +1,9 @@
 {% set is_leaf = node.children is not defined or node.children is empty %}
-<section class="docs-sidebar__section{{ nested ? ' docs-sidebar__section--nested' : '' }}{{ is_leaf ? ' docs-sidebar__section--leaf' : '' }}" data-id="{{ node._id }}">
+<section class="docs-sidebar__section{{ nested ? ' docs-sidebar__section--nested' : ' docs-sidebar__section--root' }}{{ is_leaf ? ' docs-sidebar__section--leaf' : '' }}" data-id="{{ node._id }}">
   <a class="docs-sidebar__section-title-wrapper"
     href="{{ node.uri ? '/' ~ node.uri : '/page/' ~ node._id }}"
   >
-    <div class="docs-sidebar__section-title {{ page is defined and toString(page._id) == toString(node._id) ? 'docs-sidebar__section-title--active' : '' }}">
+    <div class="docs-sidebar__section-title{% if not nested %} docs-sidebar__section-title--root{% endif %}{% if page is defined and toString(page._id) == toString(node._id) %} docs-sidebar__section-title--active{% endif %}">
       <span>
         {{ node.title | striptags }}
       </span>

--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -123,23 +123,6 @@
       margin-top: 2px;
     }
 
-    &--leaf {
-      .docs-sidebar__section-title {
-        font-size: 14px;
-        line-height: 21px;
-        height: 29px;
-
-        @media (--mobile) {
-          font-size: 16px;
-          line-height: 21px;
-        }
-      }
-
-      .docs-sidebar__section-title--active {
-        color: white;
-      }
-    }
-
     &--hidden {
       display: none;
     }
@@ -204,9 +187,28 @@
     }
   }
 
-  /* Top-level sidebar rows only: always bold (with or without children). Nested levels stay 400. */
+  /*
+   * Two typography tiers:
+   * - Root (1st level): 16px / 24 / 34px row, bold — same for branches and single links.
+   * - Nested: one shared style for all deeper levels (branches + leaves).
+   */
   &__content > .docs-sidebar__section > .docs-sidebar__section-title-wrapper > .docs-sidebar__section-title {
+    font-size: 16px;
+    line-height: 24px;
+    height: 34px;
     font-weight: 700;
+  }
+
+  .docs-sidebar__section--nested .docs-sidebar__section-title {
+    font-size: 14px;
+    line-height: 21px;
+    height: 29px;
+    font-weight: 400;
+
+    @media (--mobile) {
+      font-size: 16px;
+      line-height: 21px;
+    }
   }
 
   /* Tighter gap between root items when the previous section is collapsed. */

--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -202,10 +202,16 @@
       /* plain radius: --squircle uses mask-box-image and gets clipped by overflow:hidden on ancestors */
       border-radius: 8px;
     }
+  }
 
-    &:has(.docs-sidebar__section-toggler) {
-      font-weight: 700;
-    }
+  /* Top-level sidebar rows only: always bold (with or without children). Nested levels stay 400. */
+  &__content > .docs-sidebar__section > .docs-sidebar__section-title-wrapper > .docs-sidebar__section-title {
+    font-weight: 700;
+  }
+
+  /* Tighter gap between root items when the previous section is collapsed. */
+  &__content > .docs-sidebar__section--collapsed + .docs-sidebar__section {
+    margin-top: 12px;
   }
 
   &__section-title > span {

--- a/src/frontend/styles/components/sidebar.pcss
+++ b/src/frontend/styles/components/sidebar.pcss
@@ -187,19 +187,13 @@
     }
   }
 
-  /*
-   * Two typography tiers:
-   * - Root (1st level): 16px / 24 / 34px row, bold — same for branches and single links.
-   * - Nested: one shared style for all deeper levels (branches + leaves).
-   */
-  &__content > .docs-sidebar__section > .docs-sidebar__section-title-wrapper > .docs-sidebar__section-title {
-    font-size: 16px;
-    line-height: 24px;
-    height: 34px;
+  /* 1st-level title row (see sidebar-section.twig: --root). */
+  &__section-title--root {
     font-weight: 700;
   }
 
-  .docs-sidebar__section--nested .docs-sidebar__section-title {
+  /* Deeper levels: one style for all nested items. */
+  &__section--nested &__section-title {
     font-size: 14px;
     line-height: 21px;
     height: 29px;
@@ -211,8 +205,7 @@
     }
   }
 
-  /* Tighter gap between root items when the previous section is collapsed. */
-  &__content > .docs-sidebar__section--collapsed + .docs-sidebar__section {
+  .docs-sidebar__section--root.docs-sidebar__section--collapsed + .docs-sidebar__section--root {
     margin-top: 12px;
   }
 


### PR DESCRIPTION
## What changed
- **Typography:** Only first-level (root) sidebar entries use bold text, including leaf links with no children. Deeper nesting keeps the regular body weight.
- **Spacing:** Slightly reduced vertical gap between adjacent root sections when the previous one is collapsed (`12px` vs `20px`).

## Before
<img width="330" height="253" alt="Снимок экрана 2026-04-12 в 13 14 32" src="https://github.com/user-attachments/assets/7a8973ff-888f-4888-9668-ce526a2b6ea4" />

## After
<img width="264" height="337" alt="Снимок экрана 2026-04-12 в 14 03 46" src="https://github.com/user-attachments/assets/5494ee24-f362-46bd-a013-1f1c6ecf7546" />

